### PR TITLE
ref: Event listener improvements and cleanup

### DIFF
--- a/.project
+++ b/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>nativescript-carto</name>
+	<name>ui-carto</name>
 	<comment>Project nativescript-carto created by Buildship.</comment>
 	<projects>
 	</projects>

--- a/src/ui-carto/core/index.android.ts
+++ b/src/ui-carto/core/index.android.ts
@@ -2,23 +2,12 @@ import { BaseNative } from '../BaseNative';
 import { AltitudeKey, DefaultLatLonKeys, GenericMapPos, LatitudeKey, LongitudeKey, MapVec, ScreenBounds, ScreenPos } from './index.common';
 export * from './index.common';
 
-export const ClickType = {
-    get SINGLE() {
-        return com.carto.ui.ClickType.CLICK_TYPE_SINGLE;
-    },
-    get LONG() {
-        return com.carto.ui.ClickType.CLICK_TYPE_LONG;
-    },
-    get DOUBLE() {
-        return com.carto.ui.ClickType.CLICK_TYPE_DOUBLE;
-    },
-    get DUAL() {
-        return com.carto.ui.ClickType.CLICK_TYPE_DUAL;
-    }
-};
-
 export class MapBounds<T = DefaultLatLonKeys> extends BaseNative<com.carto.core.MapBounds, {}> {
-    constructor(public northeast?: GenericMapPos<T>, public southwest?: GenericMapPos<T>, native?: com.carto.core.MapBounds) {
+    constructor(
+        public northeast?: GenericMapPos<T>,
+        public southwest?: GenericMapPos<T>,
+        native?: com.carto.core.MapBounds
+    ) {
         super(undefined, native);
     }
     createNative() {

--- a/src/ui-carto/core/index.common.ts
+++ b/src/ui-carto/core/index.common.ts
@@ -32,6 +32,14 @@ export class ScreenBounds {
     min: ScreenPos;
     max: ScreenPos;
 }
+
+export enum ClickType {
+    SINGLE,
+    LONG,
+    DOUBLE,
+    DUAL
+}
+
 // export namespace MapBounds {
 //     function fromCoordinates(southwest: MapPos, northeast: MapPos): MapBounds;
 // }

--- a/src/ui-carto/core/index.ios.ts
+++ b/src/ui-carto/core/index.ios.ts
@@ -2,15 +2,12 @@ import { BaseNative } from '../BaseNative';
 import { AltitudeKey, DefaultLatLonKeys, GenericMapPos, LatitudeKey, LongitudeKey, MapVec, ScreenBounds, ScreenPos } from './index.common';
 export * from './index.common';
 
-export enum ClickType {
-    SINGLE = NTClickType.T_CLICK_TYPE_SINGLE,
-    LONG = NTClickType.T_CLICK_TYPE_LONG,
-    DOUBLE = NTClickType.T_CLICK_TYPE_DOUBLE,
-    DUAL = NTClickType.T_CLICK_TYPE_DUAL
-}
-
 export class MapBounds<T = DefaultLatLonKeys> extends BaseNative<NTMapBounds, {}> {
-    constructor(public northeast?: GenericMapPos<T>, public southwest?: GenericMapPos<T>, native?: NTMapBounds) {
+    constructor(
+        public northeast?: GenericMapPos<T>,
+        public southwest?: GenericMapPos<T>,
+        native?: NTMapBounds
+    ) {
         super(undefined, native);
     }
     createNative() {

--- a/src/ui-carto/ui/index.common.ts
+++ b/src/ui-carto/ui/index.common.ts
@@ -95,6 +95,13 @@ export abstract class Layers<T = any> extends BaseNative<T, {}> {
 
 @CSSType('CartoMap')
 export abstract class CartoViewBase extends ContentView {
+    public static mapReadyEvent = MapReadyEvent;
+    public static mapStableEvent = MapStableEvent;
+    public static mapIdleEvent = MapIdleEvent;
+    public static mapMovedEvent = MapMovedEvent;
+    public static mapInteractionEvent = MapInteractionEvent;
+    public static mapClickedEvent = MapClickedEvent;
+
     public mapReady = false;
     nativeProjection: any;
     @mapProperty({

--- a/src/ui-carto/ui/index.common.ts
+++ b/src/ui-carto/ui/index.common.ts
@@ -3,8 +3,8 @@ import { CSSType, ContentView } from '@nativescript/core';
 import { BaseNative } from '../BaseNative';
 import { LatitudeKey, MapPos, fromNativeMapPos } from '../core';
 import { Layer } from '../layers';
-import { nativeVectorToArray } from '../utils';
 import { bearingProperty, focusPosProperty, tiltProperty, zoomProperty } from './cssproperties';
+import { MapInfo } from '.';
 
 export const MapReadyEvent = 'mapReady';
 export const MapStableEvent = 'mapStable';
@@ -123,7 +123,7 @@ export abstract class CartoViewBase extends ContentView {
     @mapProperty maxZoom: number;
     @mapProperty restrictedPanning: boolean;
 
-    public sendEvent(eventName: string, data?) {
+    public sendEvent<T extends MapInfo = MapInfo>(eventName: string, data?: T) {
         if (this.hasListeners(eventName)) {
             this.notify({
                 eventName,

--- a/src/ui-carto/ui/index.d.ts
+++ b/src/ui-carto/ui/index.d.ts
@@ -1,5 +1,5 @@
 import { EventData, ImageSource, Style, View } from '@nativescript/core';
-import { DefaultLatLonKeys, GenericMapPos, MapBounds, ScreenBounds, ScreenPos } from '../core';
+import { ClickType, DefaultLatLonKeys, GenericMapPos, MapBounds, ScreenBounds, ScreenPos } from '../core';
 import { Layer } from '../layers';
 import { Projection } from '../projections';
 import { Layers } from './index.common';
@@ -31,27 +31,53 @@ export const MapIdleEvent: string;
 export const MapMovedEvent: string;
 export const MapClickedEvent: string;
 
+export interface MapInfo {}
+
+export interface MapGestureInfo extends MapInfo {
+    userAction: boolean;
+}
+
+export interface MapInteractionInfo extends MapGestureInfo {
+    interaction: {
+        isAnimationStarted: boolean;
+        isPanAction: boolean;
+        isRotateAction: boolean;
+        isTiltAction: boolean;
+        isZoomAction: boolean;
+    };
+}
+
+export interface MapClickInfo<T = DefaultLatLonKeys> extends MapInfo {
+    android?: any;
+    ios?: any;
+    clickInfo: {
+        duration: number;
+    };
+    clickType: ClickType;
+    position: GenericMapPos<T>;
+}
+
 export interface MapEventData extends EventData {
-    data: any;
+    data?: MapInfo;
 }
 export interface MapPosEventData<T = DefaultLatLonKeys> extends EventData {
     MapPos: GenericMapPos<T>;
 }
 
-export interface MapClickInfo<T = DefaultLatLonKeys> {
-    clickType: number;
-    clickInfo: {
-        duration: number;
-    };
-    position: GenericMapPos<T>;
+export interface MapMovedEventData extends MapEventData {
+    data: MapGestureInfo;
 }
-export interface MapInteractionInfo {
-    userAction: boolean;
-    isAnimationStarted: boolean;
-    isPanAction: boolean;
-    isRotateAction: boolean;
-    isTiltAction: boolean;
-    isZoomAction: boolean;
+
+export interface MapStableEventData extends MapEventData {
+    data: MapGestureInfo;
+}
+
+export interface MapInteractionEventData extends MapEventData {
+    data: MapInteractionInfo;
+}
+
+export interface MapClickedEventData extends MapEventData {
+    data: MapClickInfo;
 }
 
 export class MapOptions {
@@ -232,4 +258,10 @@ export class CartoMap<T = DefaultLatLonKeys> extends View {
     clearPreloadingCaches();
     cancelAllTasks();
     captureRendering(wait?: boolean): Promise<ImageSource>;
+
+    on(event: 'mapReady' | 'mapIdle', callback: (args: EventData) => void, thisArg?: any): void;
+    on(event: 'mapStable', callback: (args: MapStableEventData) => void, thisArg?: any): void;
+    on(event: 'mapMoved', callback: (args: MapMovedEventData) => void, thisArg?: any): void;
+    on(event: 'mapInteraction', callback: (args: MapInteractionEventData) => void, thisArg?: any): void;
+    on(event: 'mapClicked', callback: (args: MapClickedEventData) => void, thisArg?: any): void;
 }

--- a/src/ui-carto/ui/index.d.ts
+++ b/src/ui-carto/ui/index.d.ts
@@ -39,10 +39,10 @@ export interface MapPosEventData<T = DefaultLatLonKeys> extends EventData {
 }
 
 export interface MapClickInfo<T = DefaultLatLonKeys> {
-    clickType: number,
-    clickInfo:{
-        duration:number
-    },
+    clickType: number;
+    clickInfo: {
+        duration: number;
+    };
     position: GenericMapPos<T>;
 }
 export interface MapInteractionInfo {
@@ -177,7 +177,7 @@ export class MapOptions {
     setLongClickDuration(param0: number): void;
     getDoubleClickMaxDuration(): number;
     setDoubleClickMaxDuration(param0: number): void;
-	setLayersLabelsProcessedInReverseOrder(enabled: boolean): void;
+    setLayersLabelsProcessedInReverseOrder(enabled: boolean): void;
     isLayersLabelsProcessedInReverseOrder(): boolean;
 }
 
@@ -192,6 +192,13 @@ interface CartoMapStyle extends Style {
 }
 
 export class CartoMap<T = DefaultLatLonKeys> extends View {
+    public static mapReadyEvent = 'mapReady';
+    public static mapStableEvent = 'mapStable';
+    public static mapIdleEvent = 'mapIdle';
+    public static mapMovedEvent = 'mapMoved';
+    public static mapInteractionEvent = 'mapInteraction';
+    public static mapClickedEvent = 'mapClicked';
+
     public static setRunOnMainThread(value: boolean);
     public projection: Projection;
     focusPos: GenericMapPos<T>;

--- a/src/ui-carto/ui/index.ios.ts
+++ b/src/ui-carto/ui/index.ios.ts
@@ -118,7 +118,7 @@ class AKMapEventListenerImpl extends NSObject implements AKMapEventListener {
                     };
                 },
                 get clickType(): ClickType {
-                    return Number(mapClickInfo.getClickType());
+                    return mapClickInfo.getClickType() as number;
                 },
                 get position() {
                     return fromNativeMapPos(mapClickInfo.getClickPos());

--- a/src/ui-carto/ui/index.ios.ts
+++ b/src/ui-carto/ui/index.ios.ts
@@ -134,7 +134,7 @@ class AKMapEventListenerImpl extends NSObject implements AKMapEventListener {
                     get clickInfo() {
                         return {
                             get duration() {
-                                return (mapClickInfo as any).getClickInfo().getDuration();
+                                return mapClickInfo.getClickInfo().getDuration();
                             }
                         };
                     },


### PR DESCRIPTION
This PR does few things based on event listeners.
More specifically:
- Added support for adding event listeners in XML
- Added descriptive `on()` call types for each event name
- Replaced notify calls with existing `sendEvent` method
- Removed unneeded `hasListeners` calls
- Added generic type for data argument to `sendEvent` method
- Fixed in issue that caused mapInteraction event data payload to be inconsistent between the two platforms
- Replaced ClickType structures with a pure `ClickType` enum
- Click event clickType will now return an integer for both platforms which can be compared with new enum values (this required an additional JNI call of `swigValue()` on android)