### PR TITLE
fix: added missing js reference for map layers

### DIFF
--- a/src/ui-carto/ui/index.android.ts
+++ b/src/ui-carto/ui/index.android.ts
@@ -294,12 +294,12 @@ export class Layers extends BaseLayers<com.carto.components.Layers> {
     }
     insert(index: number, layer: Layer<any, any>) {
         super.insert(index, layer);
-        return this.native.insert(index, layer.getNative());
+        this.native.insert(index, layer.getNative());
     }
     //@ts-ignore
     set(index: number, layer: Layer<any, any>) {
         super.set(index, layer);
-        return this.native.set(index, layer.getNative());
+        this.native.set(index, layer.getNative());
     }
     remove(layer: Layer<any, any>) {
         super.remove(layer);
@@ -307,7 +307,7 @@ export class Layers extends BaseLayers<com.carto.components.Layers> {
     }
     add(layer: Layer<any, any>) {
         super.add(layer);
-        return this.native.add(layer.getNative());
+        this.native.add(layer.getNative());
     }
     //@ts-ignore
     get(index: number) {
@@ -318,7 +318,7 @@ export class Layers extends BaseLayers<com.carto.components.Layers> {
     }
     clear() {
         super.clear();
-        return this.native.clear();
+        this.native.clear();
     }
 
     // public getNative() {

--- a/src/ui-carto/ui/index.android.ts
+++ b/src/ui-carto/ui/index.android.ts
@@ -55,9 +55,10 @@ export class CartoMap<T = DefaultLatLonKeys> extends CartoViewBase {
     };
     mProjection: IProjection;
 
-    get mapView() {
-        return this.nativeViewProtected;
+    override get mapView(): com.akylas.carto.additions.AKMapView {
+        return super.mapView;
     }
+
     get projection() {
         return this.mProjection;
     }
@@ -229,42 +230,10 @@ export class CartoMap<T = DefaultLatLonKeys> extends CartoViewBase {
         this.mapView.getOptions().setRestrictedPanning(value);
     }
 
-    getLayers() {
-        if (this.mapView) {
-            return new Layers(this.mapView.getLayers());
-        }
-        return null;
-    }
-    addLayer(layer: TileLayer<any, any>, index?: number) {
-        if (this.mapView) {
-            const native: com.carto.layers.TileLayer = layer.getNative();
-            if (!!native) {
-                try {
-                    const layers = this.mapView.getLayers();
-                    if (index !== undefined && index < layers.count()) {
-                        layers.insert(index, native);
-                    } else {
-                        layers.add(native);
-                    }
-                } catch (error) {
-                    console.error(error);
-                }
-            }
-        }
+    createLayersInstance(): Layers {
+        return new Layers(this.mapView.getLayers());
     }
 
-    removeLayer(layer: TileLayer<any, any>) {
-        if (this.mapView) {
-            this.mapView.getLayers().remove(layer.getNative());
-        }
-    }
-    removeAllLayers(layers: TileLayer<any, any>[]) {
-        if (this.mapView) {
-            const vector = new com.carto.layers.LayerVector();
-            layers.forEach((l) => vector.add(l.getNative()));
-            this.mapView.getLayers().removeAll(vector);
-        }
-    }
     clearAllCaches() {
         this.mapView && this.mapView.clearAllCaches();
     }
@@ -324,36 +293,31 @@ export class Layers extends BaseLayers<com.carto.components.Layers> {
         return this.native.count();
     }
     insert(index: number, layer: Layer<any, any>) {
+        super.insert(index, layer);
         return this.native.insert(index, layer.getNative());
     }
     //@ts-ignore
     set(index: number, layer: Layer<any, any>) {
+        super.set(index, layer);
         return this.native.set(index, layer.getNative());
     }
-    removeAll(layers: Layer<any, any>[]) {
-        layers.forEach(this.remove);
-    }
     remove(layer: Layer<any, any>) {
+        super.remove(layer);
         return this.native.remove(layer.getNative());
     }
     add(layer: Layer<any, any>) {
+        super.add(layer);
         return this.native.add(layer.getNative());
     }
     //@ts-ignore
     get(index: number) {
         return this.native.get(index);
     }
-    addAll(layers: Layer<any, any>[]) {
-        layers.forEach(this.add);
-    }
-    setAll(layers: Layer<any, any>[]) {
-        this.clear();
-        this.addAll(layers);
-    }
     getAll() {
         return nativeVectorToArray(this.native.getAll());
     }
     clear() {
+        super.clear();
         return this.native.clear();
     }
 

--- a/src/ui-carto/ui/index.android.ts
+++ b/src/ui-carto/ui/index.android.ts
@@ -302,8 +302,11 @@ export class Layers extends BaseLayers<com.carto.components.Layers> {
         this.native.set(index, layer.getNative());
     }
     remove(layer: Layer<any, any>) {
-        super.remove(layer);
-        return this.native.remove(layer.getNative());
+        const removed = this.native.remove(layer.getNative());
+        if (removed) {
+            super.remove(layer);
+        }
+        return removed;
     }
     add(layer: Layer<any, any>) {
         super.add(layer);

--- a/src/ui-carto/ui/index.common.ts
+++ b/src/ui-carto/ui/index.common.ts
@@ -2,7 +2,7 @@
 import { CSSType, ContentView } from '@nativescript/core';
 import { BaseNative } from '../BaseNative';
 import { LatitudeKey, MapPos, fromNativeMapPos } from '../core';
-import { Layer, TileLayer } from '../layers';
+import { Layer } from '../layers';
 import { bearingProperty, focusPosProperty, tiltProperty, zoomProperty } from './cssproperties';
 import { MapInfo } from '.';
 
@@ -88,15 +88,25 @@ export abstract class Layers<T = any> extends BaseNative<T, {}> {
         this.mLayerArray[index] = layer;
     }
 
-    removeAll(layers: Layer<any, any>[]) {
-        layers.forEach((layer) => this.remove(layer));
+    removeAll(layers: Layer<any, any>[]): boolean {
+        let hasRemovedAll: boolean = true;
+
+        layers.forEach((layer) => {
+            if (!this.remove(layer)) {
+                if (hasRemovedAll) {
+                    hasRemovedAll = false;
+                }
+            }
+        });
+        return hasRemovedAll;
     }
 
-    remove(layer: Layer<any, any>) {
+    remove(layer: Layer<any, any>): boolean {
         const index = this.mLayerArray.indexOf(layer);
         if (index >= 1) {
             this.mLayerArray.splice(index, 1);
         }
+        return true;
     }
 
     add(layer: Layer<any, any>) {
@@ -186,7 +196,7 @@ export abstract class CartoViewBase extends ContentView {
         return this.mLayers;
     }
 
-    addLayer(layer: TileLayer<any, any>, index?: number) {
+    addLayer(layer: Layer<any, any>, index?: number) {
         const layersInstance = this.getLayers();
         if (layersInstance) {
             if (index !== undefined && index <= layersInstance.count()) {
@@ -197,14 +207,14 @@ export abstract class CartoViewBase extends ContentView {
         }
     }
 
-    removeLayer(layer: TileLayer<any, any>) {
+    removeLayer(layer: Layer<any, any>) {
         const layersInstance = this.getLayers();
         if (layersInstance) {
             layersInstance.remove(layer);
         }
     }
 
-    removeAllLayers(layers: TileLayer<any, any>[]) {
+    removeAllLayers(layers: Layer<any, any>[]) {
         const layersInstance = this.getLayers();
         if (layersInstance) {
             layersInstance.removeAll(layers);

--- a/src/ui-carto/ui/index.common.ts
+++ b/src/ui-carto/ui/index.common.ts
@@ -105,8 +105,9 @@ export abstract class Layers<T = any> extends BaseNative<T, {}> {
         const index = this.mLayerArray.indexOf(layer);
         if (index >= 1) {
             this.mLayerArray.splice(index, 1);
+            return true;
         }
-        return true;
+        return false;
     }
 
     add(layer: Layer<any, any>) {

--- a/src/ui-carto/ui/index.d.ts
+++ b/src/ui-carto/ui/index.d.ts
@@ -232,6 +232,7 @@ export class CartoMap<T = DefaultLatLonKeys> extends View {
     bearing: number;
     tilt: number;
     restrictedPanning: boolean;
+    readonly mapView: any;
     readonly metersPerPixel: number;
 
     addLayer(layer: Layer<any, any>, index?: number);

--- a/src/ui-carto/ui/index.d.ts
+++ b/src/ui-carto/ui/index.d.ts
@@ -2,8 +2,6 @@ import { EventData, ImageSource, Style, View } from '@nativescript/core';
 import { ClickType, DefaultLatLonKeys, GenericMapPos, MapBounds, ScreenBounds, ScreenPos } from '../core';
 import { Layer } from '../layers';
 import { Projection } from '../projections';
-import { Layers } from './index.common';
-export { Layers };
 
 export enum RenderProjectionMode {
     RENDER_PROJECTION_MODE_PLANAR,
@@ -207,6 +205,20 @@ export class MapOptions {
     isLayersLabelsProcessedInReverseOrder(): boolean;
 }
 
+export class Layers<T = any> {
+    abstract count(): number;
+    abstract insert(index: number, layer: Layer<any, any>): void;
+    abstract removeAll(layers: Layer<any, any>[]): boolean;
+    abstract remove(layer: Layer<any, any>): boolean;
+    abstract add(layer: Layer<any, any>): void;
+    abstract set(index: number, layer: Layer<any, any>): void;
+    abstract get(index: number): Layer<any, any>;
+    abstract addAll(layers: Layer<any, any>[]): void;
+    abstract setAll(layers: Layer<any, any>[]): void;
+    abstract getAll(): Layer<any, any>[];
+    abstract clear(): void;
+}
+
 interface CartoMapStyle extends Style {
     zoom: number;
     focusPos: GenericMapPos;
@@ -237,6 +249,7 @@ export class CartoMap<T = DefaultLatLonKeys> extends View {
 
     addLayer(layer: Layer<any, any>, index?: number);
     removeLayer(layer: Layer<any, any>);
+    removeAllLayers(layers: Layer<any, any>[]);
     getLayers(): Layers<any>;
     screenToMap(pos: ScreenPos | any): GenericMapPos<T>;
     mapToScreen(pos: GenericMapPos<T> | any): ScreenPos;

--- a/src/ui-carto/ui/index.ios.ts
+++ b/src/ui-carto/ui/index.ios.ts
@@ -146,18 +146,22 @@ class NTRendererCaptureListenerImpl extends AKRendererCaptureListener {
 }
 export class CartoMap<T = DefaultLatLonKeys> extends CartoViewBase {
     static projection = new EPSG4326();
+
     nativeProjection: NTProjection;
     mProjection: IProjection;
 
     public static setRunOnMainThread(value: boolean) {
         runOnMainThread = value;
     }
-    get mapView() {
-        return this.nativeViewProtected as AKMapView;
+
+    override get mapView(): AKMapView {
+        return super.mapView;
     }
+
     get projection() {
         return this.mProjection;
     }
+
     set projection(proj: IProjection) {
         this.mProjection = proj;
         this.nativeProjection = this.mProjection.getNative();
@@ -186,7 +190,6 @@ export class CartoMap<T = DefaultLatLonKeys> extends CartoViewBase {
 
     disposeNativeView(): void {
         this.mapView.setMapEventListener(null);
-        this.mapView.getLayers().clear();
         this.nativeProjection = null;
         this.mProjection = null;
         super.disposeNativeView();
@@ -259,38 +262,10 @@ export class CartoMap<T = DefaultLatLonKeys> extends CartoViewBase {
         this.mapView.getOptions().setRestrictedPanning(value);
     }
 
-    getLayers() {
-        if (this.mapView) {
-            return new Layers(this.mapView.getLayers());
-        }
-        return null;
-    }
-    addLayer(layer: TileLayer<any, any>, index?: number) {
-        if (this.mapView) {
-            const native: NTTileLayer = layer.getNative();
-            if (!!native) {
-                const layers = this.mapView.getLayers();
-                if (index !== undefined && index <= layers.count()) {
-                    layers.insertLayer(index, native);
-                } else {
-                    layers.add(native);
-                }
-            }
-        }
+    createLayersInstance(): Layers {
+        return new Layers(this.mapView.getLayers());
     }
 
-    removeLayer(layer: TileLayer<any, any>) {
-        if (this.mapView) {
-            this.mapView.getLayers().remove(layer.getNative());
-        }
-    }
-    removeAllLayers(layers: TileLayer<any, any>[]) {
-        if (this.mapView) {
-            const vector = NTLayerVector.alloc().init();
-            layers.forEach((l) => vector.add(l.getNative()));
-            this.mapView.getLayers().removeAll(vector);
-        }
-    }
     clearAllCaches() {
         this.mapView && this.mapView.clearAllCaches();
     }
@@ -341,36 +316,36 @@ export class Layers extends BaseLayers<NTLayers> {
         return this.native.count();
     }
     insert(index: number, layer: Layer<any, any>) {
+        super.insert(index, layer);
         return this.native.insertLayer(index, layer.getNative());
     }
     //@ts-ignore
     set(index: number, layer: Layer<any, any>) {
+        super.set(index, layer);
         return this.native.setLayer(index, layer.getNative());
     }
-    removeAll(layers: Layer<any, any>[]) {
-        layers.forEach(this.remove);
-    }
+
     remove(layer: Layer<any, any>) {
+        super.remove(layer);
         return this.native.remove(layer.getNative());
     }
     add(layer: Layer<any, any>) {
+        super.add(layer);
         return this.native.add(layer.getNative());
     }
     //@ts-ignore
     get(index: number) {
         return this.native.get(index);
     }
-    addAll(layers: Layer<any, any>[]) {
-        layers.forEach(this.add);
-    }
-    setAll(layers: Layer<any, any>[]) {
-        this.clear();
-        this.addAll(layers);
-    }
     getAll() {
         return nativeVectorToArray(this.native.getAll());
     }
     clear() {
+        super.clear();
         return this.native.clear();
     }
+
+    // public getNative() {
+    //     return this.native;
+    // }
 }

--- a/src/ui-carto/ui/index.ios.ts
+++ b/src/ui-carto/ui/index.ios.ts
@@ -317,12 +317,12 @@ export class Layers extends BaseLayers<NTLayers> {
     }
     insert(index: number, layer: Layer<any, any>) {
         super.insert(index, layer);
-        return this.native.insertLayer(index, layer.getNative());
+        this.native.insertLayer(index, layer.getNative());
     }
     //@ts-ignore
     set(index: number, layer: Layer<any, any>) {
         super.set(index, layer);
-        return this.native.setLayer(index, layer.getNative());
+        this.native.setLayer(index, layer.getNative());
     }
 
     remove(layer: Layer<any, any>) {
@@ -331,7 +331,7 @@ export class Layers extends BaseLayers<NTLayers> {
     }
     add(layer: Layer<any, any>) {
         super.add(layer);
-        return this.native.add(layer.getNative());
+        this.native.add(layer.getNative());
     }
     //@ts-ignore
     get(index: number) {
@@ -342,7 +342,7 @@ export class Layers extends BaseLayers<NTLayers> {
     }
     clear() {
         super.clear();
-        return this.native.clear();
+        this.native.clear();
     }
 
     // public getNative() {

--- a/src/ui-carto/ui/index.ios.ts
+++ b/src/ui-carto/ui/index.ios.ts
@@ -326,8 +326,11 @@ export class Layers extends BaseLayers<NTLayers> {
     }
 
     remove(layer: Layer<any, any>) {
-        super.remove(layer);
-        return this.native.remove(layer.getNative());
+        const removed = this.native.remove(layer.getNative());
+        if (removed) {
+            super.remove(layer);
+        }
+        return removed;
     }
     add(layer: Layer<any, any>) {
         super.add(layer);


### PR DESCRIPTION
Right now, there are a couple of cases of weak references being lost because carto map does not keep refs of layers on JS-side.

This PR ensures that we keep a proper reference of `Layers` instance and its layers using a JS array.
It also corrects a few types and keeps all common methods related to Layers in common file.

Additionally, method `getLayers` becomes lazy and instantiates `Layers` once during first execution, provided that native view is already initialized.
Getter `mapView` becomes common and is now added to types.
Certain `Layers` methods returned wrong type. See https://cartodb.github.io/mobile-android-samples/reference/com/carto/components/Layers.html#removeAll(com.carto.layers.LayerVector)
Methods addAll, setAll, and removeAll have been fixed as they called certain other `Layers` instance methods without `this` context.
Example of the problem:
```ts
removeAll(layers: Layer<any, any>[]) {
    layers.forEach(this.remove); // Method remove will be executed as a plain callback, missing context
}
```