### PR TITLE
fix: added synchronous handler timeout to prevent deadlock

### DIFF
--- a/packages/ui-carto/platforms/android/java/com/akylas/carto/additions/SynchronousHandler.java
+++ b/packages/ui-carto/platforms/android/java/com/akylas/carto/additions/SynchronousHandler.java
@@ -63,7 +63,7 @@ public class SynchronousHandler {
                     synchronized (runnable) {
                         try {
                             if (!runnable.isFinished()) {
-                                runnable.wait();
+                                runnable.wait(300);
                             }
                         } catch (InterruptedException is) {
                             // ignore


### PR DESCRIPTION
This PR adds a missing runnable wait timeout to avoid deadlock when main thread is too busy to handle the task given.
@farfromrefug I have set it to 300ms but since it blocks main looper, I'll leave it to your judgement.